### PR TITLE
Migrate away from PythonInterp CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.12.0)
 
 set(catkin_EXTRAS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -1,7 +1,13 @@
 # the CMake variable PYTHON_INSTALL_DIR has the same value as the Python function catkin.builder.get_python_install_dir()
 
 set(PYTHON_VERSION "$ENV{ROS_PYTHON_VERSION}" CACHE STRING "Specify specific Python version to use ('major.minor' or 'major')")
-find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
+find_package(Python ${PYTHON_VERSION} REQUIRED)
+
+# Set these legacy variables for compatibility with what PythonInterp used to do
+set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+set(PYTHON_VERSION_MAJOR ${Python_VERSION_MAJOR})
+set(PYTHON_VERSION_MINOR ${Python_VERSION_MINOR})
+set(PYTHON_VERSION_PATCH ${Python_VERSION_PATCH})
 
 message(STATUS "Using PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
 


### PR DESCRIPTION
As suggested in #1

@mikaelarguedas
> For some reason I didnt succeed to open a PR towards this fork.

Worked as it should for me. What problem did you experience?
We saw some problems with permissions in these forks in the past, there might still be lingering issues.

I'll give this a bit for people to see, but otherwise I'm happy to merge it.
Thanks @mikepurvis.